### PR TITLE
feat: Added useful information in Credentials printout

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ changes since it was written).
 ## Dependencies
 
 ```
-python3 -m pip install pycryptodome requests
+python3 -m pip install -r requirements.txt
 ```
 
 Note: Requires a version of pycryptodome that supports AES in CCM mode.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pycryptodome==3.18.0
+requests==2.31.0

--- a/wasg-register.py
+++ b/wasg-register.py
@@ -382,9 +382,11 @@ def main():
     password = decrypt(key, r["nonce"], r["tag_password"], r["enc_password"])
 
     print("Credentials:")
-    print("\tuserid = %s" % r["userid"].decode())
+    print("\tssid = Wireless@SGx")
+    print("\teap = PEAP")
+    print("\tphase2-auth = MSCHAPv2")
+    print("\tidentity = %s" % r["userid"].decode())
     print("\tpassword = %s" % password.decode())
-        
     return 0
     
 #enddef
@@ -396,10 +398,11 @@ if __name__ == "__main__":
         errprint("HTTP error: %s" % e.message)
         sys.exit(1)
     except MalformedResponseExn as e:
-        errpint("Malformed response from server: %s" % e.message)
+        errprint("Malformed response from server: %s" % e.message)
         sys.exit(1)
     except ServerErrorExn as e:
         errprint("Server responded with error message: %s" % e.message)
+        errprint("If you have registered before, please retry with -r or --retrieve-mode.")
         sys.exit(1)
     #endtry
 #endif


### PR DESCRIPTION
- Added additional useful information in the final Credentials printout to include `ssid`, `eap` and `phase2-auth` (can be copy pasted into `wpa_supplicant.conf` or NetworkManager.
- Added `requirements.txt` for easier dependencies install with tested versions, updated `README.md` to match.
- Added additional prompt to use `--retrieve-mode` if user has registered before. Sample error message from server:
`Server responded with error message: DOB & Mobile Number pair already exists`
- Fixed code typo in `errpint(...)`.